### PR TITLE
CountMembersOnThunderBySubnet return 0 if no subnet_id

### DIFF
--- a/a10_octavia/controller/worker/tasks/a10_database_tasks.py
+++ b/a10_octavia/controller/worker/tasks/a10_database_tasks.py
@@ -1230,6 +1230,8 @@ class CountLoadbalancersOnThunderBySubnet(BaseDatabaseTask):
 class CountMembersOnThunderBySubnet(BaseDatabaseTask):
 
     def execute(self, subnet, use_device_flavor, members):
+        if not subnet:
+            return 0
         if use_device_flavor:
             try:
                 count = 0


### PR DESCRIPTION
## Return 0 if no subnet_id supplied to member
Bug Fix: 
- Medium
- As a user, if I create a member without a subnet_id, the member is unable to be deleted from Octavia. It requires an Openstack operator to clean up the database and manually remove the member from the A10 Thunder device. 

## Jira Ticket
- N/A, External Contributor. 

## Technical Approach
- Similar to other tasks within the a10_database_tasks, this change evaluates if a subnet is present when running CountMembersOnThunderBySubnet and simply returns 0 if the value is not set. 

## Manual Testing
```
openstack loadbalancer create \
--vip-subnet-id vip-supnet \
--name lb1

openstack loadbalancer listener create \
--name listener1 \
--protocol TCP \
--protocol-port 80 \
lb1

openstack loadbalancer pool create \
--name pool1 \
--lb-algorithm ROUND_ROBIN \
--listener listener1 \
--protocol TCP 

openstack loadbalancer member create \
--address 192.168.1.1 \
--protocol-port 80 \
pool1
```

Verify that a member can be deleted and does not become stuck in a PENDING_* state:
`openstack loadbalancer member delete pool1 192.168.1.1
`